### PR TITLE
Feature/results by reference

### DIFF
--- a/src/promax.ts
+++ b/src/promax.ts
@@ -72,10 +72,11 @@ export class Promax<T = any> {
    * chain all of your commands together)
    * @param results
    */
-  public setResults(results: any) {
+  public setResultsOutput(results: any): Promax {
     results.valid = [];
     results.invalid = [];
     this.results = results;
+    return this;
   }
 
   public add(func: PromiseFunction<T>): Promax;

--- a/src/promax.ts
+++ b/src/promax.ts
@@ -67,6 +67,17 @@ export class Promax<T = any> {
     return Object.assign({}, defaultPromiseLimitOptions, options);
   }
 
+  /**
+   * Allows you to set the results array by reference (if you want to
+   * chain all of your commands together)
+   * @param results
+   */
+  public setResults(results: any) {
+    results.valid = [];
+    results.invalid = [];
+    this.results = results;
+  }
+
   public add(func: PromiseFunction<T>): Promax;
   public add(func: PromiseFunctionWithArgs<T>, ...args: any[]): Promax;
   // tslint:disable-next-line:unified-signatures


### PR DESCRIPTION
# Type
- Feature

# Completed
- Added the ability to set the results object (passed in by reference effectively) which allows you to get the results and the promise result array at the same time when chaining commands